### PR TITLE
style: align with `standard-GEM` template v0.5

### DIFF
--- a/.standard-GEM.md
+++ b/.standard-GEM.md
@@ -15,24 +15,24 @@ Based on the ISO guidelines, tweaked for easy understanding.
 ### Instructions
 This document serves as a checklist for creating an open source genome-scale metabolic model (GEM) on GitHub.  
 
-- [ ] 🟥 All GEMs that follow the `standard-GEM` must contain this file.  
+- [x] 🟥 All GEMs that follow the `standard-GEM` must contain this file.  
 This serves as a traceable adherence to the standard, manually confirmed by the original authors. This file must be edited only with [checkmarks](https://help.github.com/en/github/managing-your-work-on-github/about-task-lists), in order to support automatic parsing and validation of this file. Some of the checkmarks are pre-applied based on the contents of the `standard-GEM` template repository. GEM authors have the responsibility of checking that their model repository does follow the guidelines entirely.  
 With further updates to `standard-GEM`, one should paste over the new version of this file, and see that the changes in the new guidelines are met.
 
 Repository creation
 -------------------
-- [ ] 🟨 Navigate to [standard-GEM](https://github.com/MetabolicAtlas/standard-GEM/) and click on the button `Use this template`  
+- [x] 🟨 Navigate to [standard-GEM](https://github.com/MetabolicAtlas/standard-GEM/) and click on the button `Use this template`  
 The `standard-GEM` template can be used to initiate a repository. This will copy the contents of the _master_ branch into the new repository, which can be either private or public.
 
-- [ ] 🟥 Pick a repository name  
+- [x] 🟥 Pick a repository name  
 The name must be either a common name, KEGG organism, or taxonomy-derived short name, followed by the extension `-GEM` or `-GSMM`. The `-GEM` extension is preferred to ease pronunciation. The name can be prefixed by an abbreviation, eg `ec` (enzyme constrained), `sec` (with secretory pathways), `mito` (with mitochondrion pathways), `pro` (with protein structures).  
 Example: `ecYeast-GEM`
 
-- [ ] 🟥 Pick a repository description  
+- [x] 🟥 Pick a repository description  
 The description must include the taxonomic classification in full.  
 Example: `The consensus GEM for Saccharomyces cerevisiae`
 
-- [ ] 🟥 Add repository topic  
+- [x] 🟥 Add repository topic  
 The topic `standard-GEM` must be added. Other topics like `genome-scale-models`, `systems-biology` can be added. Having this topic on your repository enables automatic finding using the GitHub API, and automatic validation of the standard.  
 Topics are not copied from `standard-GEM`, so they need to be added manually.
 
@@ -42,13 +42,13 @@ The URL can be the link to the publication/pre-print/website where the model is 
 
 Repository workflow
 -------------------
-- [ ] 🟥 Git branches  
-The GEM repository must have at least two branches: _master_ and _develop_.
+- [x] 🟥 Git branches  
+The GEM repository must have at least two branches: _master_ and _devel_.
 
-- [ ] 🟥 Releases  
+- [x] 🟥 Releases  
 Releases must use the tag format `X.X.X` where X are numbers, according to [semantic versioning principles](https://semver.org/). The last field, also called “patch”, can also be used to indicate changes to the repository that do not actually change the GEM itself. The use of a `v` before the version number (`v1.0`) [is discouraged](https://semver.org/#is-v123-a-semantic-version). For more information about releases see the [documentation at GitHub](https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository).  
 
-- [ ] 🟨 Commits  
+- [x] 🟨 Commits  
 Commit messages can follow the style of semantic commits.
 
 
@@ -72,14 +72,14 @@ The repository must contain a `/code` folder. This folder must contain all the c
 - [ ] 🟥 `/data/README.md`  
 The repository must contain a `/data` folder. This folder contains the data used in generating the model. It must also include a `README.md` file that describes how the folder is organized.
 
-- [ ] 🟥 `/model`  
+- [x] 🟥 `/model`  
 The repository must contain `/model` folder.  
 This folder must contain the model files, in multiple formats, according to the table below. As a general guideline, binary formats (`.mat`, `.xlsx`) must not exist on any other branches than _master_. The main reason for this is that binary files cannot be diff'ed, which means changes cannot be compared to previous versions, thus increasing the chance of errors. Moreover, with time, the size of the repository can create difficulties, and we cannot yet recommend storing these files with Git LFS, as it introducs complexity.  
 For more information on the `sbtab` file format, see [sbtab.net](https://sbtab.net).  
 All model files must be named the same as the repository, and with the appropriate extension.  
 Example: `yeast-GEM.mat`
 
-| Model file format | _master_ branch | _develop_ and other branches |
+| Model file format | _master_ branch | _devel_ and other branches |
 | ----------------- | --------------- | ---------------------------- |
 | JSON `.json`      | can             ||
 | Matlab `.mat`     | should          | must not                     |
@@ -93,7 +93,7 @@ Example: `yeast-GEM.mat`
 - [x] 🟥 `/LICENSE.md`  
 The repository must contain a license file. The default license is [CC-BY 4.0 International](https://creativecommons.org/licenses/by/4.0/). Unless a different license is desired, the file does not require modification.
 
-- [ ] 🟥 `/README.md`  
+- [x] 🟥 `/README.md`  
 The repository must contain a `README.md` file. A default file is provided, and the adequate contents must be filled in.  
 The `/README.md` file must include a version badge. A default is provided in the file.  
 Additionally, the `/README.md` file should contain the [Zenodo](https://zenodo.org) badge. As soon as the first public release is in made, the repository [should be archived via Zenodo](https://github.com/MetabolicAtlas/standard-GEM/wiki/FAQ#zenodo), and the corresponding badge be updated. A default is provided in the file.  

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 
 # Mouse-GEM: The generic genome-scale metabolic model of _Mus musculus_
 
-[![Version](https://badge.fury.io/gh/{{organization or username}}%2F{{repository name}}.svg)](https://badge.fury.io/gh/sysbiochalmers/mouse-gem)
-[![Zenodo](https://zenodo.org/badge/{{Zenodo ID}}.svg)](https://zenodo.org/badge/latestdoi/{{Zenodo ID}})
+[![GitHub version](https://badge.fury.io/gh/sysbiochalmers%2FMouse-GEM.svg)](https://badge.fury.io/gh/sysbiochalmers%2FMouse-GEM)
 
 
 #### Brief Model Description


### PR DESCRIPTION
### Main improvements in this PR:
* This PR is to address the issue raised in #5, by adjusting `standard-GEM.md` file to reflect the repo status and align with the specifications defined by [`standard-GEM`](https://github.com/MetabolicAtlas/standard-GEM)

**I hereby confirm that I have:**

- [ ] Tested my code on my own computer for running the model
- [X] Selected `devel` as a target branch
