### PR TITLE
Fix: only annotate model before SBML export

### DIFF
--- a/code/masterScriptMouseGEM.m
+++ b/code/masterScriptMouseGEM.m
@@ -43,9 +43,9 @@ if isequal(rxnAssoc.rxns, mouseGEM.rxns) && isequal(metAssoc.mets, mouseGEM.mets
     exportTsvFile(metAssoc,'../model/metabolites.tsv');
 end
 
-mouseGEM = annotateGEM(mouseGEM,'../model',{'rxn','met'});  % add annotation data to structure
-mouseGEM.id = regexprep(mouseGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 save('../model/Mouse-GEM.mat', 'mouseGEM');
 exportYaml(mouseGEM, '../model/Mouse-GEM.yml');
+mouseGEM = annotateGEM(mouseGEM,'../model',{'rxn','met'});  % add annotation data to structure
+mouseGEM.id = regexprep(mouseGEM.id,'-','');  % remove dash from model ID since it causes problems with SBML I/O
 exportModel(mouseGEM, '../model/Mouse-GEM.xml');
 


### PR DESCRIPTION
### Main improvements in this PR:
Many of the model annotation fields added to the model by the `annotateGEM` function are non-standard and therefore can cause problems with many functions (see Issue #16). However, the function is helpful for adding the annotation information into the SBML file.

This PR re-orders the final steps of the `masterScriptMouseGEM.m` function to add the annotation information to the model _after_ the `.mat` and `.yml` formats have been written, but _before_ writing the SBML model format.

**Note:** this change should also be made in the other Animal GEM repos.

**I hereby confirm that I have:**

- [X] Tested my code on my own computer for running the model
- [X] Selected `develop` as a target branch
